### PR TITLE
scripts: run_parsers.py: move to upstream mavlink parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
-# ArduPilot-Parameter-Respotiory
-Have all generated parameters in a single place
+# ArduPilot Vehicle Metadata
+
+Collects generated parameters into a single place, together with generated documentation references of used/handled MAVLink messages for each firmware version.
+
+Functionality is implemented in the `scripts` folder, and run automatically via workflows (in `.github/workflows`). All other folders are generated content.

--- a/scripts/run_parsers.py
+++ b/scripts/run_parsers.py
@@ -120,12 +120,8 @@ class Groundskeeper:
         tag_names = [tag.path[len('refs/tags/'):] for tag in self.repository.tags]
         last_ground_change = self.get_last_ground_change()
 
-        # Prepare for MAVLink parsing - always use the latest script (since it might cover new messages)
-        #shutil.copy(f'{self.repository_path}/Tools/scripts/mavlink_parse.py', self.temp_folder)
-        # TEMPORARY WORKAROUND UNTIL ArduPilot/ardupilot#27226 IS MERGED
-        from urllib.request import urlretrieve
-        urlretrieve("https://raw.githubusercontent.com/ES-Alexander/ardupilot/refs/heads/mavlink-messages-rst/Tools/scripts/mavlink_parse.py", f'{self.temp_folder}/mavlink_parse.py')
-        # TEMP-END
+        # Prepare for MAVLink parsing - always use the latest script (since it might cover new dialects or messages)
+        shutil.copy(f'{self.repository_path}/Tools/scripts/mavlink_parse.py', self.temp_folder)
 
         # Get only valid tag names
         tags = []


### PR DESCRIPTION
The idea was always to use the script from the official repo, it was just temporarily using a dev branch while the documentation-ready form of the script was being approved.

- [x] Waiting on ArduPilot/ardupilot#27226

Added a README update to reflect the repo's usage, and describe where the magic happens.