### PR TITLE
scripts: run_parsers: groundskeeper: fix missing timezone bug

### DIFF
--- a/scripts/run_parsers.py
+++ b/scripts/run_parsers.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 
 from packaging import version
-from datetime import datetime
+from datetime import datetime, timezone
 
 class Groundskeeper:
     repository_url = 'https://github.com/ArduPilot/ardupilot'
@@ -102,7 +102,7 @@ class Groundskeeper:
 
         # Determine last ground change of some other repo
         last_commit_date = repository.head.commit.committed_date
-        return datetime.fromtimestamp(last_commit_date)
+        return datetime.fromtimestamp(last_commit_date).astimezone(timezone.utc)
 
     @staticmethod
     def get_vehicle_prefix(vehicle_type: str):


### PR DESCRIPTION
@patrickelectric identified that there was an issue after #18 was merged, and it seems I accidentally added a bug.

The new date-time checking uses timezone-aware times, which were failing to compare properly to the naive times provided by the repo's last commit time. This PR specifies those last commit times as being in UTC, which (as far as I understand) is what they are.